### PR TITLE
http_server_spec setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/http_server_spec"]
 	path = test/http_server_spec
-	url = git@github.com:kelseyroy/http_server_spec.git
+	url = https://github.com/kelseyroy/http_server_spec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/http_server_spec"]
 	path = test/http_server_spec
-	url = git@github.com:8thlight/http_server_spec.git
+	url = git@github.com:kelseyroy/http_server_spec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/http_server_spec"]
 	path = test/http_server_spec
-	url = https://github.com/kelseyroy/http_server_spec.git
+	url = git@github.com:kelseyroy/http_server_spec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/http_server_spec"]
+	path = test/http_server_spec
+	url = git@github.com:8thlight/http_server_spec.git

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A user should be able to interact with the echo server as follows:
 2. Use your terminal to navigate into your new http_server folder and install project dependencies by running `mix compile`.
 3. You may notice that the `test/http_server_spec` submodule exists, but has no files. Use your terminal to navigate into the `test/http_server_spec` folder and call `git submodule init` and `git submodule update` to initialize your local git modules configuration file and fetch all data from the [http_server_spec](https://github.com/8thlight/http_server_spec) project.
 4. To start the Echo Server, call `mix start` from within the http_server folder.
-5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 5000` in a local terminal.
+5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4000` in a local terminal.
 
 ## Testing
 ### Running the ExUnit Test Suite:

--- a/README.md
+++ b/README.md
@@ -24,4 +24,26 @@ A user should be able to interact with the echo server as follows:
 2. Use your terminal to navigate into your new http_server folder and install project dependencies by running `mix compile`.
 3. To start the Echo Server, call `mix start` from within the http_server folder.
 4. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4040` in a local terminal.
-5. To run the tests, call `mix test` from within the http_server folder.
+
+## Testing
+### Running the ExUnit Test Suite:
+To run the ExUnit test suite, call `mix test` from within the http_server folder.
+
+### Acceptance Tests:
+
+#### Dependencies
+* Ruby 2.7.6
+
+### Running the Acceptance Test Suite:
+1. Start your HTTP server by calling `mix start` from within the http_server folder.
+2. Use your terminal to navigate into the `test/http_server_spec` folder and install project dependencies by running `bundle install`.
+3. Once the server is running, call `rake test` from within the http_server_spec folder.
+4. You can also run the tests from a specific section of the features:
+
+```
+rake test:f1 # Run all of the tests in 01_getting_started
+rake test:f2 # Run all of the tests in 02_structured_data
+rake test:f3 # Run all of the tests in 03_file_server
+rake test:f4 # Run all of the tests in 04_todo_list
+```
+See `test/http_server_spec/README.md` for more information about the acceptance tests.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A user should be able to interact with the echo server as follows:
 ## Setup
 1. [Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local computer.
 2. Use your terminal to navigate into your new http_server folder and install project dependencies by running `mix compile`.
-3. You may notice that the `test/http_server_spec` submodule exists, but has no files. Call `git submodule init` and `git submodule update` from within the http_server folder to initialize your local git modules configuration file and fetch all data from the [http_server_spec](https://github.com/8thlight/http_server_spec) project.
+3. You may notice that the `test/http_server_spec` submodule exists, but has no files. Use your terminal to navigate into the `test/http_server_spec` folder and call `git submodule init` and `git submodule update` to initialize your local git modules configuration file and fetch all data from the [http_server_spec](https://github.com/8thlight/http_server_spec) project.
 4. To start the Echo Server, call `mix start` from within the http_server folder.
 5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4040` in a local terminal.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run the ExUnit test suite, call `mix test` from within the http_server folder
 #### Dependencies
 * Ruby 2.7.6
 
-### Running the Acceptance Test Suite:
+#### Running the Acceptance Test Suite:
 1. Start your HTTP server by calling `mix start` from within the http_server folder.
 2. Use your terminal to navigate into the `test/http_server_spec` folder and install project dependencies by running `bundle install`.
 3. Once the server is running, call `rake test` from within the http_server_spec folder.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ A user should be able to interact with the echo server as follows:
 ## Setup
 1. [Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local computer.
 2. Use your terminal to navigate into your new http_server folder and install project dependencies by running `mix compile`.
-3. To start the Echo Server, call `mix start` from within the http_server folder.
-4. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4040` in a local terminal.
+3. You may notice that the `test/http_server_spec` submodule exists, but has no files. Call `git submodule init` and `git submodule update` from within the http_server folder to initialize your local git modules configuration file and fetch all data from the [http_server_spec](https://github.com/8thlight/http_server_spec) project.
+4. To start the Echo Server, call `mix start` from within the http_server folder.
+5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4040` in a local terminal.
 
 ## Testing
 ### Running the ExUnit Test Suite:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A user should be able to interact with the echo server as follows:
 2. Use your terminal to navigate into your new http_server folder and install project dependencies by running `mix compile`.
 3. You may notice that the `test/http_server_spec` submodule exists, but has no files. Use your terminal to navigate into the `test/http_server_spec` folder and call `git submodule init` and `git submodule update` to initialize your local git modules configuration file and fetch all data from the [http_server_spec](https://github.com/8thlight/http_server_spec) project.
 4. To start the Echo Server, call `mix start` from within the http_server folder.
-5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 4040` in a local terminal.
+5. To connect to the Server as a client, [install telnet](https://formulae.brew.sh/formula/telnet) and call `telnet 127.0.0.1 5000` in a local terminal.
 
 ## Testing
 ### Running the ExUnit Test Suite:

--- a/lib/tasks.ex
+++ b/lib/tasks.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Start do
   use Mix.Task
 
   def run(_) do
-    port = String.to_integer(System.get_env("PORT") || "4040")
+    port = String.to_integer(System.get_env("PORT") || "5000")
     HTTPServer.accept(port)
   end
 end

--- a/lib/tasks.ex
+++ b/lib/tasks.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Start do
   use Mix.Task
 
   def run(_) do
-    port = String.to_integer(System.get_env("PORT") || "5000")
+    port = String.to_integer(System.get_env("PORT") || "4000")
     HTTPServer.accept(port)
   end
 end


### PR DESCRIPTION
Adds 
* [http_server_spec](https://github.com/kelseyroy/http_server_spec) as a [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in `test` directory
* Directions to README for how to setup submodule and run acceptance tests
* `@wip` above all acceptance test scenarios except for post, as that's the first test I want to see pass at the moment!