### PR TITLE
[Campsite] Simplifies http_spec Rakefile port config

### DIFF
--- a/test/http_server_spec/Rakefile
+++ b/test/http_server_spec/Rakefile
@@ -1,61 +1,62 @@
-def is_server_running?(port)
-  system("lsof -i:#{port}", out: '/dev/null')
+PORT = 4000
+
+def is_server_running?
+  system("lsof -i:#{PORT}", out: '/dev/null')
 end
 
-def server_not_running_error(port)
+def server_not_running_error
   STDERR.puts '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
-  STDERR.puts "I tried to connect to the server on PORT #{port}."
+  STDERR.puts "I tried to connect to the server on port #{PORT}."
   STDERR.puts 'However, I was unable to successfully connect.'
   STDERR.puts 'Maybe check if the server is up and running?'
   STDERR.puts '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
   exit 1
 end
 
-PORT = 4000
 
 desc "Run all of the tests in the suite"
 task :test do
-  if is_server_running?(PORT)
+  if is_server_running?
     puts `bundle exec spinach`
   else
-    server_not_running_error(PORT)
+    server_not_running_error
   end
 end
 
 namespace :test do
   desc "Run all of the tests in 01_getting_started"
   task :f1 do
-    if is_server_running?(PORT)
+    if is_server_running?
       puts `bundle exec spinach --tags 01-getting-started`
     else
-      server_not_running_error(PORT)
+      server_not_running_error
     end
   end
 
   desc "Run all of the tests in 02_structured_data"
   task :f2 do
-    if is_server_running?(PORT)
+    if is_server_running?
       puts `bundle exec spinach --tags 02-structured-data`
     else
-      server_not_running_error(PORT)
+      server_not_running_error
     end
   end
 
   desc "Run all of the tests in 03_file_server"
   task :f3 do
-    if is_server_running?(PORT)
+    if is_server_running?
       puts `bundle exec spinach --tags 03-file-server`
     else
-      server_not_running_error(PORT)
+      server_not_running_error
     end
   end
 
   desc "Run all of the tests in 04_todo_list"
   task :f4 do
-    if is_server_running?(PORT)
+    if is_server_running?
       puts `bundle exec spinach --tags 04-todo-list`
     else
-      server_not_running_error(PORT)
+      server_not_running_error
     end
   end
 end
@@ -64,3 +65,4 @@ desc "Start a demo server with working endpoints"
 task :server do
   `ruby server.rb`
 end
+


### PR DESCRIPTION
## Changes:
- Eliminates the passing of constant `PORT` into methods that already have access to it.