### PR TITLE
Campsite - removes explicit mentions of HEAD and OPTIONS from routes methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ Each route takes the following structure:
 ```
 def routes, 
   do: %{
-    "/PATH" => &HandlerModule.handle/1
+    "/PATH" => %{
+        handler: &HandlerModule,
+        methods: ["METHOD"]
+      }
   }
 ```
 
 * `routes/0` is a function that holds the routes in a Map data structure. The server path acts as the routes key, with the handler functionality as the value.
 * `/PATH` is a path on the server.
-* `&HandlerModule.handle/1` is the function that is executed when the route is matched.
+* `HandlerModule` is the module that is executed when the route is matched.
+* `methods: ["METHOD"]` is a list of [HTTP request method](https://en.wikipedia.org/wiki/HTTP#Request_methods) that the path can respond to. The methods are represented as a string in all capital letters. Possible methods you can include are: ["GET", "POST", "PUT", "DELETE"]. "HEAD" and "OPTIONS" methods should not be specified, as their functionality is already handled by the server itself.
 
 It's important to note that any custom routes you create should be added to the existing `routes/0` map in the `HTTPServer.Routes` module in `lib/routes.ex`. It can also be helpful to setup the full name of your `HandlerModule` as an `alias/2` at the top of the `HTTPServer.Routes` module, but that's not strictly necessary.
 
@@ -113,7 +117,10 @@ defmodule HTTPServer.Routes do
   
   def routes, 
     do: %{
-      "/PATH" => &HelloWorld.handle/1
+      "/PATH" => %{
+        handler: HandlerModule,
+        methods: ["GET"]
+      } 
     }
 end
 ```
@@ -135,7 +142,21 @@ defmodule HTTPServer.Handlers.HelloWorld do
 end
 ```
 
-And the `HTTPServer.Routes` module can remain the same!
+And finally update the `HTTPServer.Routes` module to reflect the newly added method:
+
+```
+defmodule HTTPServer.Routes do
+  alias HTTPServer.Handlers.HelloWorld
+  
+  def routes, 
+    do: %{
+      "/PATH" => %{
+        handler: HandlerModule,
+        methods: ["GET", "POST"]
+      } 
+    }
+end
+```
 
 ## Testing
 ### Running the ExUnit Test Suite:

--- a/lib/http_server_fixture/routes.ex
+++ b/lib/http_server_fixture/routes.ex
@@ -3,27 +3,27 @@ defmodule HTTPServerFixture.Routes do
     do: %{
       "/echo_body" => %{
         handler: HTTPServerFixture.SimplePost,
-        methods: ["POST", "OPTIONS"]
+        methods: ["POST"]
       },
       "/simple_get" => %{
         handler: HTTPServerFixture.SimpleGet,
-        methods: ["GET", "HEAD", "OPTIONS"]
+        methods: ["GET"]
       },
       "/simple_get_with_body" => %{
         handler: HTTPServerFixture.SimpleGetWithBody,
-        methods: ["GET", "HEAD", "OPTIONS"]
+        methods: ["GET"]
       },
       "/head_request" => %{
         handler: HTTPServerFixture.SimpleHead,
-        methods: ["GET", "HEAD", "OPTIONS"]
+        methods: ["GET"]
       },
       "/method_options" => %{
         handler: HTTPServerFixture.Options,
-        methods: ["GET", "HEAD", "OPTIONS"]
+        methods: ["GET"]
       },
       "/method_options2" => %{
         handler: HTTPServerFixture.OptionsTwo,
-        methods: ["GET", "POST", "PUT", "HEAD", "OPTIONS"]
+        methods: ["GET", "POST", "PUT"]
       }
     }
 end

--- a/lib/http_server_test_fixture/mock_routes.ex
+++ b/lib/http_server_test_fixture/mock_routes.ex
@@ -3,11 +3,11 @@ defmodule HTTPServerTestFixture.MockRoutes do
     do: %{
       "/test_post" => %{
         handler: HTTPServerTestFixture.Handlers.MockPost,
-        methods: ["POST", "OPTIONS"]
+        methods: ["POST"]
       },
       "/test_get" => %{
         handler: HTTPServerTestFixture.Handlers.MockGet,
-        methods: ["GET", "HEAD", "OPTIONS"]
+        methods: ["GET"]
       }
     }
 end

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -21,20 +21,27 @@ defmodule HTTPServer.Response do
     }
   end
 
-  def build_headers(body, methods) do
-    %{
-      "Content-Length" => "#{String.length(body)}",
-      "Content-Type" => "text/plain",
-      "Host" => "127.0.0.1:4000",
-      "Allow" => "#{Enum.join(methods, ", ")}"
-    }
-  end
-
   def build_headers(body) do
     %{
       "Content-Length" => "#{String.length(body)}",
       "Content-Type" => "text/plain",
       "Host" => "127.0.0.1:4000"
+    }
+  end
+
+  def build_headers(body, methods) do
+    methods =
+      if Enum.member?(methods, "GET") do
+        methods ++ ["HEAD", "OPTIONS"]
+      else
+        methods ++ ["OPTIONS"]
+      end
+
+    %{
+      "Content-Length" => "#{String.length(body)}",
+      "Content-Type" => "text/plain",
+      "Host" => "127.0.0.1:4000",
+      "Allow" => "#{Enum.join(methods, ", ")}"
     }
   end
 


### PR DESCRIPTION
A quick/small campsite update to remove explicit mentions of HEAD and OPTIONS from routes methods

Adds:
* functionality to `build_headers/2` that adds HEAD and OPTIONS into methods list

Removes:
* HEAD and OPTIONS from methods list in all routes files

Updates:
* the README file to reflect the new routes structure