### PR TITLE
Campsite - Refactors handle/1 to return {status_code,  body,  headers}

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -1,4 +1,6 @@
 defmodule HTTPServer.Handler do
   alias HTTPServer.Request
-  @callback handle(req :: %Request{}) :: {status_code :: integer(), body :: term()}
+
+  @callback handle(req :: %Request{}) ::
+              {status_code :: integer(), body :: term(), headers :: map()}
 end

--- a/lib/handlers/not_found.ex
+++ b/lib/handlers/not_found.ex
@@ -1,9 +1,12 @@
 defmodule HTTPServer.Handlers.NotFound do
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(req) do
-    {404,
-     "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"}
+    body =
+      "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"
+
+    {404, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_fixture/handlers/options.ex
+++ b/lib/http_server_fixture/handlers/options.ex
@@ -1,9 +1,10 @@
 defmodule HTTPServerFixture.Options do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, ""}
+    {200, "", Response.build_headers("")}
   end
 end

--- a/lib/http_server_fixture/handlers/options_two.ex
+++ b/lib/http_server_fixture/handlers/options_two.ex
@@ -1,17 +1,20 @@
 defmodule HTTPServerFixture.OptionsTwo do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, ""}
+    {200, "", Response.build_headers("")}
   end
 
   def handle(%Request{method: "PUT"} = req) do
-    {200, req.body}
+    body = req.body
+    {200, body, Response.build_headers(body)}
   end
 
   def handle(%Request{method: "POST"} = req) do
-    {200, req.body}
+    body = req.body
+    {200, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_get.ex
+++ b/lib/http_server_fixture/handlers/simple_get.ex
@@ -1,9 +1,10 @@
 defmodule HTTPServerFixture.SimpleGet do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, ""}
+    {200, "", Response.build_headers("")}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_get_with_body.ex
+++ b/lib/http_server_fixture/handlers/simple_get_with_body.ex
@@ -1,9 +1,11 @@
 defmodule HTTPServerFixture.SimpleGetWithBody do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, "Hello world"}
+    body = "Hello world"
+    {200, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_head.ex
+++ b/lib/http_server_fixture/handlers/simple_head.ex
@@ -1,9 +1,11 @@
 defmodule HTTPServerFixture.SimpleHead do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, "This body does not show up in a HEAD request"}
+    body = "This body does not show up in a HEAD request"
+    {200, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_post.ex
+++ b/lib/http_server_fixture/handlers/simple_post.ex
@@ -1,9 +1,11 @@
 defmodule HTTPServerFixture.SimplePost do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "POST"} = req) do
-    {200, req.body}
+    body = req.body
+    {200, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_test_fixture/mock_handlers/mock_get.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_get.ex
@@ -1,9 +1,11 @@
 defmodule HTTPServerTestFixture.Handlers.MockGet do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "GET"} = _req) do
-    {200, "this is a mocked get with a body"}
+    body = "this is a mocked get with a body"
+    {200, body, Response.build_headers(body)}
   end
 end

--- a/lib/http_server_test_fixture/mock_handlers/mock_post.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_post.ex
@@ -1,9 +1,11 @@
 defmodule HTTPServerTestFixture.Handlers.MockPost do
   alias HTTPServer.Request
+  alias HTTPServer.Response
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "POST"} = req) do
-    {200, req.body}
+    body = req.body
+    {200, body, Response.build_headers(req.body)}
   end
 end

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -25,7 +25,7 @@ defmodule HTTPServer.Response do
     %{
       "Content-Length" => "#{String.length(body)}",
       "Content-Type" => "text/plain",
-      "Host" => "127.0.0.1:4000"
+      "Host" => "0.0.0.0:4000"
     }
   end
 

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -29,7 +29,11 @@ defmodule HTTPServer.Response do
     }
   end
 
-  def build_headers(body, methods) do
+  def build_headers(body, headers) do
+    Map.merge(build_headers(body), headers)
+  end
+
+  def build_allow_header(methods) do
     methods =
       if Enum.member?(methods, "GET") do
         methods ++ ["HEAD", "OPTIONS"]
@@ -38,9 +42,6 @@ defmodule HTTPServer.Response do
       end
 
     %{
-      "Content-Length" => "#{String.length(body)}",
-      "Content-Type" => "text/plain",
-      "Host" => "127.0.0.1:4000",
       "Allow" => "#{Enum.join(methods, ", ")}"
     }
   end

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -18,27 +18,25 @@ defmodule HTTPServer.Router do
 
   defp router(_req = %Request{method: "OPTIONS"}, path_info) do
     {:ok, methods} = Map.fetch(path_info, :methods)
-    headers = Response.build_headers("", methods)
+    allow_header = Response.build_allow_header(methods)
+    headers = Response.build_headers("", allow_header)
     Response.send_resp(200, "", headers)
   end
 
   defp router(req = %Request{method: "HEAD"}, path_info) do
     {:ok, handler} = Map.fetch(path_info, :handler)
-    {status_code, body} = handler.handle(%{req | method: "GET"})
-    headers = Response.build_headers(body)
+    {status_code, _body, headers} = handler.handle(%{req | method: "GET"})
     Response.send_resp(status_code, "", headers)
   end
 
   defp router(req, path_info) do
     {:ok, handler} = Map.fetch(path_info, :handler)
-    {status_code, body} = handler.handle(req)
-    headers = Response.build_headers(body)
+    {status_code, body, headers} = handler.handle(req)
     Response.send_resp(status_code, body, headers)
   end
 
   defp route_not_found(req) do
-    {status_code, body} = NotFound.handle(req)
-    headers = Response.build_headers(body)
+    {status_code, body, headers} = NotFound.handle(req)
     Response.send_resp(status_code, body, headers)
   end
 end

--- a/test/http_request_test.exs
+++ b/test/http_request_test.exs
@@ -8,7 +8,7 @@ defmodule HTTPServerTest.Request do
   test "returns properly formatted HTTP GET request without body" do
     message =
       "GET /simple_get HTTP/1.1#{@carriage_return}" <>
-        "Host: 127.0.0.1 4000#{@carriage_return}" <>
+        "Host: 0.0.0.0:4000#{@carriage_return}" <>
         "User-Agent: ExampleBrowser/1.0#{@carriage_return}" <>
         "Accept: */*#{@carriage_return}" <>
         "Content-Type: text/plain#{@carriage_return}" <>
@@ -24,7 +24,7 @@ defmodule HTTPServerTest.Request do
         "Accept" => "*/*",
         "Content-Length" => "9",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: ""
@@ -36,7 +36,7 @@ defmodule HTTPServerTest.Request do
   test "returns properly formatted HTTP POST request" do
     message =
       "POST /echo_body HTTP/1.1#{@carriage_return}" <>
-        "Host: 127.0.0.1 4000#{@carriage_return}" <>
+        "Host: 0.0.0.0:4000#{@carriage_return}" <>
         "User-Agent: ExampleBrowser/1.0#{@carriage_return}" <>
         "Accept: */*#{@carriage_return}" <>
         "Content-Type: text/plain#{@carriage_return}" <>
@@ -52,7 +52,7 @@ defmodule HTTPServerTest.Request do
         "Accept" => "*/*",
         "Content-Length" => "9",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: "some body"

--- a/test/http_response_test.exs
+++ b/test/http_response_test.exs
@@ -12,7 +12,7 @@ defmodule HTTPServerTest.Response do
     headers = %{
       "Content-Length" => "15",
       "Content-Type" => "text/plain",
-      "Host" => "127.0.0.1:4000"
+      "Host" => "0.0.0.0:4000"
     }
 
     expected_parsed_response = %Response{
@@ -22,7 +22,7 @@ defmodule HTTPServerTest.Response do
       headers: %{
         "Content-Length" => "15",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body: "this is my body"
     }
@@ -38,7 +38,7 @@ defmodule HTTPServerTest.Response do
       headers: %{
         "Content-Length" => "15",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body: "this is my body"
     }
@@ -47,7 +47,7 @@ defmodule HTTPServerTest.Response do
       "HTTP/1.1 200 OK#{@carriage_return}" <>
         "Content-Length: 15#{@carriage_return}" <>
         "Content-Type: text/plain#{@carriage_return}" <>
-        "Host: 127.0.0.1:4000#{@carriage_return}" <>
+        "Host: 0.0.0.0:4000#{@carriage_return}" <>
         "#{@carriage_return}" <>
         "this is my body"
 

--- a/test/http_router_test.exs
+++ b/test/http_router_test.exs
@@ -15,7 +15,7 @@ defmodule HTTPServerTest.Router do
         "Accept" => "*/*",
         "Content-Length" => "9",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: "testing testing 123"
@@ -28,7 +28,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Content-Length" => "19",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body: "testing testing 123"
     }
@@ -43,7 +43,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: ""
@@ -56,7 +56,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Content-Length" => "32",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body: "this is a mocked get with a body"
     }
@@ -71,7 +71,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: ""
@@ -84,7 +84,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Content-Length" => "32",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body: ""
     }
@@ -101,7 +101,7 @@ defmodule HTTPServerTest.Router do
         "Accept" => "*/*",
         "Content-Length" => "9",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: ""
@@ -114,7 +114,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Content-Length" => "128",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000"
+        "Host" => "0.0.0.0:4000"
       },
       body:
         "The requested URL /test-not-found was not found on this server. See the README for instructions on how to customize your routes!"
@@ -130,7 +130,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
-        "Host" => "127.0.0.1 4000",
+        "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
       body: ""
@@ -143,7 +143,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Content-Length" => "0",
         "Content-Type" => "text/plain",
-        "Host" => "127.0.0.1:4000",
+        "Host" => "0.0.0.0:4000",
         "Allow" => "GET, HEAD, OPTIONS"
       },
       body: ""


### PR DESCRIPTION
Changes:
* all handlers to return `{status_code,  body,  headers}`
* `router/2` no longer builds headers
* `build_headers/2` now has parameters of `body` and `headers`
* host in response headers from 127.0.0.1:4000 to 0.0.0.0:4000

Adds:
* `build_allow_header/1` to HTTPServer.Response to separate the OPTIONS header creation responsibility from `build_headers/2 `