### PR TITLE
BUG FIX: Incorrect hostname in config.yml

### DIFF
--- a/test/http_server_spec/features/support/config.yml
+++ b/test/http_server_spec/features/support/config.yml
@@ -1,4 +1,4 @@
 server:
-  hostname: "127.0.0.1"
+  hostname: "0.0.0.0"
   port: 4000
   protocol: "http"


### PR DESCRIPTION
Changes `hostname: "127.0.0.1"` to `hostname: "0.0.0.0"` in config.yml of http_server_spec folder so that Feature: Simple Redirect can pass.