### PR TITLE
BUG FIX: Removes outdated reference to ClientRoutes in HTTPServer.Router

### DIFF
--- a/lib/router.ex
+++ b/lib/router.ex
@@ -2,9 +2,9 @@ defmodule HTTPServer.Router do
   alias HTTPServer.Response
   alias HTTPServer.Request
   alias HTTPServer.Handlers.NotFound
-  alias HTTPServer.Routes.ClientRoutes
+  alias HTTPServer.Routes
 
-  @routes Application.compile_env(:http_server, :routes, ClientRoutes)
+  @routes Application.compile_env(:http_server, :routes, Routes)
 
   def router(req) do
     case Map.fetch(@routes.routes, req.path) do


### PR DESCRIPTION
Removes alias to previously deleted `HTTPServer.Routes.ClientRoutes` in `HTTPServer.Router`. Changes default value passed to `Application.compile_env/3` to `HTTPServer.Routes`.