### PR TITLE
Campsite - Improved Server Side Logging

### DIFF
--- a/lib/config/dev.exs
+++ b/lib/config/dev.exs
@@ -2,3 +2,6 @@ import Config
 
 config :http_server,
   routes: HTTPServer.Routes
+
+config :logger,
+  backends: [:console]

--- a/lib/config/integration_test.exs
+++ b/lib/config/integration_test.exs
@@ -2,3 +2,9 @@ import Config
 
 config :http_server,
   routes: HTTPServerFixture.Routes
+
+config :logger,
+  backends: [:console],
+  compile_time_purge_matching: [
+    [level_lower_than: :error]
+  ]

--- a/lib/config/test.exs
+++ b/lib/config/test.exs
@@ -2,3 +2,9 @@ import Config
 
 config :http_server,
   routes: HTTPServerTestFixture.MockRoutes
+
+config :logger,
+  backends: [:console],
+  compile_time_purge_matching: [
+    [level_lower_than: :error]
+  ]


### PR DESCRIPTION
Adds `Request` and `Response` logging, server side

- configured logger to default to the `:console` for all environments (`dev`, `test`, `integration_test`)
- configured logger to only log at `:error` level for `test` and `integration_tests` environments

<img width="943" alt="image" src="https://github.com/kelseyroy/http_server/assets/26009042/8da55e84-e0ce-47de-a104-e59ee17149b8">
