### PR TITLE
Method Not Allowed

### DIFF
--- a/lib/handlers/method_not_allowed.ex
+++ b/lib/handlers/method_not_allowed.ex
@@ -1,4 +1,5 @@
 defmodule HTTPServer.Handlers.MethodNotAllowed do
+  alias HTTPServer.Response.Headers
   import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
   @routes Application.compile_env(:http_server, :routes, Routes)
@@ -10,7 +11,7 @@ defmodule HTTPServer.Handlers.MethodNotAllowed do
     body = ""
 
     headers =
-      build()
+      %Headers{}
       |> content_length(body)
       |> content_type()
       |> host(req.headers)

--- a/lib/handlers/method_not_allowed.ex
+++ b/lib/handlers/method_not_allowed.ex
@@ -1,0 +1,21 @@
+defmodule HTTPServer.Handlers.MethodNotAllowed do
+  import HTTPServer.Response.HeadersBuilder
+  @behaviour HTTPServer.Handler
+  @routes Application.compile_env(:http_server, :routes, Routes)
+
+  @impl HTTPServer.Handler
+  def handle(req) do
+    methods = @routes.routes[req.path][:methods]
+
+    body = ""
+
+    headers =
+      build()
+      |> content_length(body)
+      |> content_type()
+      |> host(req.headers)
+      |> allow(methods)
+
+    {405, body, headers}
+  end
+end

--- a/lib/http_server_fixture/routes.ex
+++ b/lib/http_server_fixture/routes.ex
@@ -26,7 +26,7 @@ defmodule HTTPServerFixture.Routes do
         methods: ["GET", "POST", "PUT"]
       },
       "/redirect" => %{
-        handler: HTTPServer.Handlers.Redirect,
+        handler: HTTPServer.Router.Handlers.Redirect,
         methods: ["GET"],
         location: "/simple_get"
       }

--- a/lib/http_server_test_fixture/mock_routes.ex
+++ b/lib/http_server_test_fixture/mock_routes.ex
@@ -10,7 +10,7 @@ defmodule HTTPServerTestFixture.MockRoutes do
         methods: ["GET"]
       },
       "/test_redirect" => %{
-        handler: HTTPServer.Handlers.Redirect,
+        handler: HTTPServer.Router.Handlers.Redirect,
         methods: ["GET"],
         location: "/test_get"
       }

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -27,7 +27,8 @@ defmodule HTTPServer.Response do
       200 => "OK",
       204 => "NO CONTENT",
       404 => "NOT FOUND",
-      301 => "MOVED PERMANENTLY"
+      301 => "MOVED PERMANENTLY",
+      405 => "METHOD NOT ALLOWED"
     }[status_code]
   end
 

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -9,11 +9,15 @@ defmodule HTTPServer.Router do
   @routes Application.compile_env(:http_server, :routes, Routes)
 
   def router(req) do
-    with {:ok, path_info} <- Map.fetch(@routes.routes, req.path),
-         true <- is_method_allowed(req.method, path_info) do
-      router(req, path_info)
-    else
-      :error -> route_not_found(req)
+    case Map.fetch(@routes.routes, req.path) do
+      {:ok, path_info} -> route_if_allowed(req, path_info)
+      _ -> route_not_found(req)
+    end
+  end
+
+  defp route_if_allowed(req = %Request{method: method}, path_info) do
+    case is_method_allowed(method, path_info) do
+      true -> router(req, path_info)
       false -> method_not_allowed(req)
     end
   end

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -1,9 +1,9 @@
 defmodule HTTPServer.Router do
-  alias HTTPServer.Handlers.MethodNotAllowed
+  alias HTTPServer.Router.Handlers.MethodNotAllowed
   alias HTTPServer.Response
   alias HTTPServer.Request
-  alias HTTPServer.Handlers.NotFound
-  alias HTTPServer.Handlers.Options
+  alias HTTPServer.Router.Handlers.NotFound
+  alias HTTPServer.Router.Handlers.Options
   alias HTTPServer.Routes
 
   @routes Application.compile_env(:http_server, :routes, Routes)

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -47,7 +47,10 @@ defmodule HTTPServer.Router do
 
   defp is_method_allowed(req_method, path_info) do
     {:ok, methods} = Map.fetch(path_info, :methods)
-    head = req_method == "HEAD" && Enum.member?(methods, "GET")
-    Enum.member?(methods, req_method) || req_method == "OPTIONS" || head
+    is_method_in_methods = Enum.member?(methods, req_method)
+    is_head_allowed = req_method == "HEAD" && Enum.member?(methods, "GET")
+    is_options = req_method == "OPTIONS"
+
+    is_options || is_method_in_methods || is_head_allowed
   end
 end

--- a/lib/router/handlers/method_not_allowed.ex
+++ b/lib/router/handlers/method_not_allowed.ex
@@ -1,4 +1,4 @@
-defmodule HTTPServer.Handlers.Options do
+defmodule HTTPServer.Router.Handlers.MethodNotAllowed do
   alias HTTPServer.Response.Headers
   import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
@@ -17,6 +17,6 @@ defmodule HTTPServer.Handlers.Options do
       |> host(req.headers)
       |> allow(methods)
 
-    {200, body, headers}
+    {405, body, headers}
   end
 end

--- a/lib/router/handlers/not_found.ex
+++ b/lib/router/handlers/not_found.ex
@@ -1,22 +1,19 @@
-defmodule HTTPServer.Handlers.MethodNotAllowed do
+defmodule HTTPServer.Router.Handlers.NotFound do
   alias HTTPServer.Response.Headers
   import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
-  @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
   def handle(req) do
-    methods = @routes.routes[req.path][:methods]
-
-    body = ""
+    body =
+      "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"
 
     headers =
       %Headers{}
       |> content_length(body)
       |> content_type()
       |> host(req.headers)
-      |> allow(methods)
 
-    {405, body, headers}
+    {404, body, headers}
   end
 end

--- a/lib/router/handlers/options.ex
+++ b/lib/router/handlers/options.ex
@@ -1,19 +1,22 @@
-defmodule HTTPServer.Handlers.NotFound do
+defmodule HTTPServer.Router.Handlers.Options do
   alias HTTPServer.Response.Headers
   import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
+  @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
   def handle(req) do
-    body =
-      "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"
+    methods = @routes.routes[req.path][:methods]
+
+    body = ""
 
     headers =
       %Headers{}
       |> content_length(body)
       |> content_type()
       |> host(req.headers)
+      |> allow(methods)
 
-    {404, body, headers}
+    {200, body, headers}
   end
 end

--- a/lib/router/handlers/redirect.ex
+++ b/lib/router/handlers/redirect.ex
@@ -1,4 +1,4 @@
-defmodule HTTPServer.Handlers.Redirect do
+defmodule HTTPServer.Router.Handlers.Redirect do
   alias HTTPServer.Response.Headers
   import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler

--- a/test/http_router_test.exs
+++ b/test/http_router_test.exs
@@ -180,4 +180,35 @@ defmodule HTTPServerTest.Router do
 
     assert Router.router(request) == expected_response
   end
+
+  test "returns 405 Method Not Found Response to GET request at /test_post" do
+    request = %Request{
+      method: "GET",
+      path: "/test_post",
+      resource: "HTTP/1.1",
+      headers: %{
+        "Accept" => "*/*",
+        "Content-Length" => 9,
+        "Content-Type" => "text/plain",
+        "Host" => "0.0.0.0:4000",
+        "User-Agent" => "ExampleBrowser/1.0"
+      },
+      body: "testing testing 123"
+    }
+
+    expected_response = %Response{
+      status_code: 405,
+      status_message: "METHOD NOT ALLOWED",
+      resource: "HTTP/1.1",
+      headers: %{
+        content_length: 0,
+        content_type: "text/plain",
+        host: "0.0.0.0:4000",
+        allow: "POST, OPTIONS"
+      },
+      body: ""
+    }
+
+    assert Router.router(request) == expected_response
+  end
 end

--- a/test/http_server_spec/features/01_getting_started/method_not_allowed.feature
+++ b/test/http_server_spec/features/01_getting_started/method_not_allowed.feature
@@ -1,12 +1,12 @@
 @method-not-allowed @01-getting-started
 Feature: Method Not Allowed
-@wip
+
   Scenario: Finding POST for an endpoint with only GET
     Given I make a POST request to "/simple_get"
     Then my response should have status code 405
     And my response should have allowed headers of GET, HEAD, OPTIONS
     And my response should have an empty body
-@wip
+
   Scenario: Finding DELETE for an endpoint with only GET
     Given I make a DELETE request to "/simple_get_with_body"
     Then my response should have status code 405


### PR DESCRIPTION
Adds:
* 405 status code and message
* `HTTPServer.Handlers.MethodNotAllowed` which access the methods from the application environment 
* `with` `else` block to` router/1`
* `is_method_allowed/2` to Router
* `method_not_allowed/1` to Router
* relevant tests