### PR TITLE
STEPPING-STONE: Changes how Response is built for Structured Data

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -2,5 +2,5 @@ defmodule HTTPServer.Handler do
   alias HTTPServer.Request
 
   @callback handle(req :: %Request{}) ::
-              {status_code :: integer(), body :: term(), headers :: map()}
+              {status_code :: integer(), body :: term(), media_type :: atom()}
 end

--- a/lib/http_server_fixture/handlers/options.ex
+++ b/lib/http_server_fixture/handlers/options.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerFixture.Options do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/options.ex
+++ b/lib/http_server_fixture/handlers/options.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerFixture.Options do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = ""
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/options_two.ex
+++ b/lib/http_server_fixture/handlers/options_two.ex
@@ -1,43 +1,20 @@
 defmodule HTTPServerFixture.OptionsTwo do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 
   def handle(%Request{method: "PUT"} = req) do
     body = req.body
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 
   def handle(%Request{method: "POST"} = req) do
     body = req.body
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/options_two.ex
+++ b/lib/http_server_fixture/handlers/options_two.ex
@@ -8,13 +8,13 @@ defmodule HTTPServerFixture.OptionsTwo do
     {200, body, :text}
   end
 
-  def handle(%Request{method: "PUT"} = req) do
-    body = req.body
+  def handle(%Request{method: "PUT", body: body} = _req) do
+    body = body
     {200, body, :text}
   end
 
-  def handle(%Request{method: "POST"} = req) do
-    body = req.body
+  def handle(%Request{method: "POST", body: body} = _req) do
+    body = body
     {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/options_two.ex
+++ b/lib/http_server_fixture/handlers/options_two.ex
@@ -3,17 +3,17 @@ defmodule HTTPServerFixture.OptionsTwo do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = ""
     {200, body, :text}
   end
 
-  def handle(%Request{method: "PUT", body: body} = _req) do
+  def handle(%Request{method: "PUT", body: body}) do
     body = body
     {200, body, :text}
   end
 
-  def handle(%Request{method: "POST", body: body} = _req) do
+  def handle(%Request{method: "POST", body: body}) do
     body = body
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/simple_get.ex
+++ b/lib/http_server_fixture/handlers/simple_get.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerFixture.SimpleGet do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = ""
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/simple_get.ex
+++ b/lib/http_server_fixture/handlers/simple_get.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerFixture.SimpleGet do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_get_with_body.ex
+++ b/lib/http_server_fixture/handlers/simple_get_with_body.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerFixture.SimpleGetWithBody do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = "Hello world"
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_get_with_body.ex
+++ b/lib/http_server_fixture/handlers/simple_get_with_body.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerFixture.SimpleGetWithBody do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = "Hello world"
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/simple_head.ex
+++ b/lib/http_server_fixture/handlers/simple_head.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerFixture.SimpleHead do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = "This body does not show up in a HEAD request"
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/simple_head.ex
+++ b/lib/http_server_fixture/handlers/simple_head.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerFixture.SimpleHead do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = "This body does not show up in a HEAD request"
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_post.ex
+++ b/lib/http_server_fixture/handlers/simple_post.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerFixture.SimplePost do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "POST", body: body} = _req) do
+  def handle(%Request{method: "POST", body: body}) do
     body = body
     {200, body, :text}
   end

--- a/lib/http_server_fixture/handlers/simple_post.ex
+++ b/lib/http_server_fixture/handlers/simple_post.ex
@@ -3,8 +3,8 @@ defmodule HTTPServerFixture.SimplePost do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "POST"} = req) do
-    body = req.body
+  def handle(%Request{method: "POST", body: body} = _req) do
+    body = body
     {200, body, :text}
   end
 end

--- a/lib/http_server_fixture/handlers/simple_post.ex
+++ b/lib/http_server_fixture/handlers/simple_post.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerFixture.SimplePost do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "POST"} = req) do
     body = req.body
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_test_fixture/mock_handlers/mock_get.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_get.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerTestFixture.Handlers.MockGet do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = _req) do
+  def handle(%Request{method: "GET"}) do
     body = "this is a mocked get with a body"
     {200, body, :text}
   end

--- a/lib/http_server_test_fixture/mock_handlers/mock_get.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_get.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerTestFixture.Handlers.MockGet do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "GET"} = req) do
+  def handle(%Request{method: "GET"} = _req) do
     body = "this is a mocked get with a body"
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/http_server_test_fixture/mock_handlers/mock_post.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_post.ex
@@ -3,7 +3,7 @@ defmodule HTTPServerTestFixture.Handlers.MockPost do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "POST", body: body} = _req) do
+  def handle(%Request{method: "POST", body: body}) do
     body = body
     {200, body, :text}
   end

--- a/lib/http_server_test_fixture/mock_handlers/mock_post.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_post.ex
@@ -3,8 +3,8 @@ defmodule HTTPServerTestFixture.Handlers.MockPost do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "POST"} = req) do
-    body = req.body
+  def handle(%Request{method: "POST", body: body} = _req) do
+    body = body
     {200, body, :text}
   end
 end

--- a/lib/http_server_test_fixture/mock_handlers/mock_post.ex
+++ b/lib/http_server_test_fixture/mock_handlers/mock_post.ex
@@ -1,19 +1,10 @@
 defmodule HTTPServerTestFixture.Handlers.MockPost do
   alias HTTPServer.Request
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "POST"} = req) do
     body = req.body
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -24,31 +24,35 @@ defmodule HTTPServer.Response do
 
   def build(req = %Request{method: "HEAD"}, status_code, res_body, media_type) do
     resp =
-      new()
+      %__MODULE__{}
+      |> resource()
       |> status(status_code)
       |> body(res_body)
-      |> Headers.build(req, media_type)
+      |> headers(req, media_type)
 
     send_resp(%{resp | body: ""})
   end
 
   def build(req, status_code, res_body, media_type) do
-    new()
+    %__MODULE__{}
+    |> resource()
     |> status(status_code)
     |> body(res_body)
-    |> Headers.build(req, media_type)
+    |> headers(req, media_type)
     |> send_resp()
   end
 
-  def new() do
-    %__MODULE__{
-      status_code: nil,
-      status_message: nil,
-      resource: "HTTP/1.1",
-      headers: Headers.new(),
-      body: nil
-    }
-  end
+  def headers(
+        res = %__MODULE__{
+          status_code: status_code,
+          body: body
+        },
+        req,
+        media_type
+      ),
+      do: %{res | headers: Headers.build(req, status_code, body, media_type)}
+
+  def resource(res), do: %{res | resource: "HTTP/1.1"}
 
   def status(res, status_code),
     do: %{res | status_code: status_code, status_message: status_message(status_code)}

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -65,11 +65,19 @@ defmodule HTTPServer.Response do
     }[status_code]
   end
 
-  def format_response(res) do
-    "#{res.resource} #{res.status_code} #{res.status_message}" <>
+  def format_response(
+        _res = %__MODULE__{
+          resource: resource,
+          status_code: status_code,
+          status_message: status_message,
+          body: body,
+          headers: headers
+        }
+      ) do
+    "#{resource} #{status_code} #{status_message}" <>
       @carriage_return <>
-      "#{Headers.format_response_headers(res.headers)}" <>
+      "#{Headers.format_response_headers(headers)}" <>
       @carriage_return <>
-      res.body
+      body
   end
 end

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -1,9 +1,15 @@
 defmodule HTTPServer.Response do
+  alias HTTPServer.Request
   alias HTTPServer.Response.Headers
-  defstruct status_code: nil, status_message: "", resource: nil, headers: %{}, body: ""
+
+  defstruct status_code: nil,
+            status_message: "",
+            resource: nil,
+            headers: %{},
+            body: ""
 
   @type t :: %__MODULE__{
-          status_code: 200 | 204 | 404,
+          status_code: 200 | 204 | 404 | 301 | 405,
           status_message: String.t(),
           resource: String.t(),
           headers: %Headers{},
@@ -12,15 +18,42 @@ defmodule HTTPServer.Response do
 
   @carriage_return "\r\n"
 
-  def send_resp(status_code, body, headers) do
+  def send_resp(resp) do
+    %{resp | headers: Headers.collect_headers(resp.headers)}
+  end
+
+  def build(req = %Request{method: "HEAD"}, status_code, res_body, media_type) do
+    resp =
+      new()
+      |> status(status_code)
+      |> body(res_body)
+      |> Headers.build(req, media_type)
+
+    send_resp(%{resp | body: ""})
+  end
+
+  def build(req, status_code, res_body, media_type) do
+    new()
+    |> status(status_code)
+    |> body(res_body)
+    |> Headers.build(req, media_type)
+    |> send_resp()
+  end
+
+  def new() do
     %__MODULE__{
-      status_code: status_code,
-      status_message: status_message(status_code),
+      status_code: nil,
+      status_message: nil,
       resource: "HTTP/1.1",
-      headers: Headers.collect_headers(headers),
-      body: body
+      headers: Headers.new(),
+      body: nil
     }
   end
+
+  def status(res, status_code),
+    do: %{res | status_code: status_code, status_message: status_message(status_code)}
+
+  def body(res, body), do: %{res | body: body}
 
   defp status_message(status_code) do
     %{
@@ -37,6 +70,6 @@ defmodule HTTPServer.Response do
       @carriage_return <>
       "#{Headers.format_response_headers(res.headers)}" <>
       @carriage_return <>
-      "#{res.body}"
+      res.body
   end
 end

--- a/lib/response/headers.ex
+++ b/lib/response/headers.ex
@@ -12,48 +12,28 @@ defmodule HTTPServer.Response.Headers do
           allow: list(String.t())
         }
 
-  def build(
-        %Request{method: "OPTIONS", path: path, headers: headers},
-        _status_code,
-        body,
-        media_type
-      ) do
+  def build(%Request{method: "OPTIONS", path: path, headers: headers}, _status_code, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)
     |> allow(@routes.routes[path][:methods])
   end
 
-  def build(
-        %Request{path: path, headers: headers},
-        _status_code = 405,
-        body,
-        media_type
-      ) do
+  def build(%Request{path: path, headers: headers}, 405, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)
     |> allow(@routes.routes[path][:methods])
   end
 
-  def build(
-        %Request{path: path, headers: headers},
-        _status_code = 301,
-        body,
-        media_type
-      ) do
+  def build(%Request{path: path, headers: headers}, 301, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)
     |> location(@routes.routes[path][:location])
   end
 
-  def build(
-        %Request{headers: headers},
-        _status_code,
-        body,
-        media_type
-      ) do
+  def build(%Request{headers: headers}, _status_code, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)

--- a/lib/response/headers.ex
+++ b/lib/response/headers.ex
@@ -13,7 +13,7 @@ defmodule HTTPServer.Response.Headers do
         }
 
   def build(
-        _req = %Request{method: "OPTIONS", path: path, headers: headers},
+        %Request{method: "OPTIONS", path: path, headers: headers},
         _status_code,
         body,
         media_type
@@ -25,7 +25,7 @@ defmodule HTTPServer.Response.Headers do
   end
 
   def build(
-        _req = %Request{path: path, headers: headers},
+        %Request{path: path, headers: headers},
         _status_code = 405,
         body,
         media_type
@@ -37,7 +37,7 @@ defmodule HTTPServer.Response.Headers do
   end
 
   def build(
-        _req = %Request{path: path, headers: headers},
+        %Request{path: path, headers: headers},
         _status_code = 301,
         body,
         media_type
@@ -49,7 +49,7 @@ defmodule HTTPServer.Response.Headers do
   end
 
   def build(
-        _req = %Request{headers: headers},
+        %Request{headers: headers},
         _status_code,
         body,
         media_type

--- a/lib/response/headers.ex
+++ b/lib/response/headers.ex
@@ -1,6 +1,5 @@
 defmodule HTTPServer.Response.Headers do
   alias HTTPServer.Request
-  alias HTTPServer.Response
   defstruct content_length: nil, content_type: nil, host: nil, location: nil, allow: nil
   import HTTPServer.Response.HeadersBuilder
   @routes Application.compile_env(:http_server, :routes, Routes)
@@ -13,59 +12,51 @@ defmodule HTTPServer.Response.Headers do
           allow: list(String.t())
         }
 
-  def new() do
-    %__MODULE__{}
-  end
-
   def build(
-        res = %Response{headers: headers, body: body},
         _req = %Request{method: "OPTIONS", path: path, headers: headers},
+        _status_code,
+        body,
         media_type
       ) do
-    options_headers =
-      headers
-      |> content(media_type, body)
-      |> host(headers)
-      |> allow(@routes.routes[path][:methods])
-
-    %{res | headers: options_headers}
+    %__MODULE__{}
+    |> content(media_type, body)
+    |> host(headers)
+    |> allow(@routes.routes[path][:methods])
   end
 
   def build(
-        res = %Response{headers: headers, body: body, status_code: 405},
         _req = %Request{path: path, headers: headers},
+        _status_code = 405,
+        body,
         media_type
       ) do
-    allowed_methods_headers =
-      headers
-      |> content(media_type, body)
-      |> host(headers)
-      |> allow(@routes.routes[path][:methods])
-
-    %{res | headers: allowed_methods_headers}
+    %__MODULE__{}
+    |> content(media_type, body)
+    |> host(headers)
+    |> allow(@routes.routes[path][:methods])
   end
 
   def build(
-        res = %Response{headers: headers, body: body, status_code: 301},
         _req = %Request{path: path, headers: headers},
+        _status_code = 301,
+        body,
         media_type
       ) do
-    redirect_headers =
-      headers
-      |> content(media_type, body)
-      |> host(headers)
-      |> allow(@routes.routes[path][:methods])
-
-    %{res | headers: redirect_headers}
+    %__MODULE__{}
+    |> content(media_type, body)
+    |> host(headers)
+    |> location(@routes.routes[path][:location])
   end
 
-  def build(res, _req = %Request{headers: headers}, media_type) do
-    headers =
-      res.headers
-      |> content(media_type, res.body)
-      |> host(headers)
-
-    %{res | headers: headers}
+  def build(
+        _req = %Request{headers: headers},
+        _status_code,
+        body,
+        media_type
+      ) do
+    %__MODULE__{}
+    |> content(media_type, body)
+    |> host(headers)
   end
 
   def collect_headers(headers) do

--- a/lib/response/headers_builder.ex
+++ b/lib/response/headers_builder.ex
@@ -1,10 +1,34 @@
 defmodule HTTPServer.Response.HeadersBuilder do
-  def content_length(headers, body), do: %{headers | content_length: String.length(body)}
-  def content_type(headers), do: %{headers | content_type: "text/plain"}
+  defp content_length(headers, body), do: %{headers | content_length: byte_size(body)}
+  defp content_type(headers, media_type), do: %{headers | content_type: media_type}
   def host(headers, req_headers), do: %{headers | host: "#{get_host(req_headers)}"}
 
-  def location(headers, req_headers, path),
-    do: %{headers | location: "http://#{get_host(req_headers)}#{path}"}
+  def content(headers, :text, body) do
+    headers
+    |> content_length(body)
+    |> content_type("text/plain;charset=utf-8")
+  end
+
+  def content(headers, :html, body) do
+    headers
+    |> content_length(body)
+    |> content_type("text/html;charset=utf-8")
+  end
+
+  def content(headers, :json, json_body) do
+    headers
+    |> content_length(json_body)
+    |> content_type("application/json;charset=utf-8")
+  end
+
+  def content(headers, :xml, body) do
+    headers
+    |> content_length(body)
+    |> content_type("application/xml;charset=utf-8")
+  end
+
+  def location(headers, path),
+    do: %{headers | location: "http://#{Map.get(headers, :host)}#{path}"}
 
   def allow(headers, methods) do
     methods =

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -23,30 +23,30 @@ defmodule HTTPServer.Router do
   end
 
   defp router(req = %Request{method: "OPTIONS"}, _path_info) do
-    {status_code, body, headers} = Options.handle(req)
-    Response.send_resp(status_code, body, headers)
+    {status_code, body, media_type} = Options.handle(req)
+    Response.build(req, status_code, body, media_type)
   end
 
   defp router(req = %Request{method: "HEAD"}, path_info) do
     {:ok, handler} = Map.fetch(path_info, :handler)
-    {status_code, _body, headers} = handler.handle(%{req | method: "GET"})
-    Response.send_resp(status_code, "", headers)
+    {status_code, body, media_type} = handler.handle(%{req | method: "GET"})
+    Response.build(req, status_code, body, media_type)
   end
 
   defp router(req, path_info) do
     {:ok, handler} = Map.fetch(path_info, :handler)
-    {status_code, body, headers} = handler.handle(req)
-    Response.send_resp(status_code, body, headers)
+    {status_code, body, media_type} = handler.handle(req)
+    Response.build(req, status_code, body, media_type)
   end
 
   defp route_not_found(req) do
-    {status_code, body, headers} = NotFound.handle(req)
-    Response.send_resp(status_code, body, headers)
+    {status_code, body, media_type} = NotFound.handle(req)
+    Response.build(req, status_code, body, media_type)
   end
 
   defp method_not_allowed(req) do
-    {status_code, body, headers} = MethodNotAllowed.handle(req)
-    Response.send_resp(status_code, body, headers)
+    {status_code, body, media_type} = MethodNotAllowed.handle(req)
+    Response.build(req, status_code, body, media_type)
   end
 
   defp is_method_allowed(req_method, path_info) do

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -8,8 +8,8 @@ defmodule HTTPServer.Router do
 
   @routes Application.compile_env(:http_server, :routes, Routes)
 
-  def router(req) do
-    case Map.fetch(@routes.routes, req.path) do
+  def router(req = %Request{path: path}) do
+    case Map.fetch(@routes.routes, path) do
       {:ok, path_info} -> route_if_allowed(req, path_info)
       _ -> route_not_found(req)
     end

--- a/lib/router/handlers/method_not_allowed.ex
+++ b/lib/router/handlers/method_not_allowed.ex
@@ -1,22 +1,9 @@
 defmodule HTTPServer.Router.Handlers.MethodNotAllowed do
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
-  @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
-  def handle(req) do
-    methods = @routes.routes[req.path][:methods]
-
+  def handle(_req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-      |> allow(methods)
-
-    {405, body, headers}
+    {405, body, :text}
   end
 end

--- a/lib/router/handlers/not_found.ex
+++ b/lib/router/handlers/not_found.ex
@@ -1,6 +1,4 @@
 defmodule HTTPServer.Router.Handlers.NotFound do
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
@@ -8,12 +6,6 @@ defmodule HTTPServer.Router.Handlers.NotFound do
     body =
       "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"
 
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-
-    {404, body, headers}
+    {404, body, :text}
   end
 end

--- a/lib/router/handlers/not_found.ex
+++ b/lib/router/handlers/not_found.ex
@@ -1,10 +1,11 @@
 defmodule HTTPServer.Router.Handlers.NotFound do
+  alias HTTPServer.Request
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(req) do
+  def handle(_req = %Request{path: path}) do
     body =
-      "The requested URL #{req.path} was not found on this server. See the README for instructions on how to customize your routes!"
+      "The requested URL #{path} was not found on this server. See the README for instructions on how to customize your routes!"
 
     {404, body, :text}
   end

--- a/lib/router/handlers/not_found.ex
+++ b/lib/router/handlers/not_found.ex
@@ -3,7 +3,7 @@ defmodule HTTPServer.Router.Handlers.NotFound do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(_req = %Request{path: path}) do
+  def handle(%Request{path: path}) do
     body =
       "The requested URL #{path} was not found on this server. See the README for instructions on how to customize your routes!"
 

--- a/lib/router/handlers/options.ex
+++ b/lib/router/handlers/options.ex
@@ -1,22 +1,9 @@
 defmodule HTTPServer.Router.Handlers.Options do
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
-  @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
-  def handle(req) do
-    methods = @routes.routes[req.path][:methods]
-
+  def handle(_req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-      |> allow(methods)
-
-    {200, body, headers}
+    {200, body, :text}
   end
 end

--- a/lib/router/handlers/redirect.ex
+++ b/lib/router/handlers/redirect.ex
@@ -1,22 +1,9 @@
 defmodule HTTPServer.Router.Handlers.Redirect do
-  alias HTTPServer.Response.Headers
-  import HTTPServer.Response.HeadersBuilder
   @behaviour HTTPServer.Handler
-  @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
-  def handle(req) do
-    {:ok, path_info} = Map.fetch(@routes.routes, req.path)
-    {:ok, location} = Map.fetch(path_info, :location)
+  def handle(_req) do
     body = ""
-
-    headers =
-      %Headers{}
-      |> content_length(body)
-      |> content_type()
-      |> host(req.headers)
-      |> location(req.headers, location)
-
-    {301, body, headers}
+    {301, body, :text}
   end
 end

--- a/test/http_response_test.exs
+++ b/test/http_response_test.exs
@@ -1,19 +1,28 @@
 defmodule HTTPServerTest.Response do
   use ExUnit.Case
-  alias HTTPServer.Response.Headers
   alias HTTPServer.Response
+  alias HTTPServer.Request
   doctest HTTPServer
 
   @carriage_return "\r\n"
 
-  test "returns a properly formatted 200 Response object when given {status_code, body, headers}" do
+  test "returns a properly formatted 200 Response object when given {request, status_code, body, media_type}" do
     status_code = 200
     body = "this is my body"
+    media_type = :text
 
-    headers = %Headers{
-      content_length: "15",
-      content_type: "text/plain",
-      host: "0.0.0.0:4000"
+    request = %Request{
+      method: "GET",
+      path: "/simple_get",
+      resource: "HTTP/1.1",
+      headers: %{
+        "Accept" => "*/*",
+        "Content-Length" => "0",
+        "Content-Type" => "text/plain;charset=utf-8",
+        "Host" => "0.0.0.0:4000",
+        "User-Agent" => "ExampleBrowser/1.0"
+      },
+      body: ""
     }
 
     expected_parsed_response = %Response{
@@ -21,14 +30,14 @@ defmodule HTTPServerTest.Response do
       status_message: "OK",
       resource: "HTTP/1.1",
       headers: %{
-        content_length: "15",
-        content_type: "text/plain",
+        content_length: 15,
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body: "this is my body"
     }
 
-    assert Response.send_resp(status_code, body, headers) == expected_parsed_response
+    assert Response.build(request, status_code, body, media_type) == expected_parsed_response
   end
 
   test "returns properly formatted response as a string" do
@@ -38,7 +47,7 @@ defmodule HTTPServerTest.Response do
       resource: "HTTP/1.1",
       headers: %{
         content_length: "15",
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body: "this is my body"
@@ -47,7 +56,7 @@ defmodule HTTPServerTest.Response do
     expected_parsed_response =
       "HTTP/1.1 200 OK#{@carriage_return}" <>
         "Content-Length: 15#{@carriage_return}" <>
-        "Content-Type: text/plain#{@carriage_return}" <>
+        "Content-Type: text/plain;charset=utf-8#{@carriage_return}" <>
         "Host: 0.0.0.0:4000#{@carriage_return}" <>
         "#{@carriage_return}" <>
         "this is my body"

--- a/test/http_router_test.exs
+++ b/test/http_router_test.exs
@@ -14,7 +14,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Accept" => "*/*",
         "Content-Length" => 9,
-        "Content-Type" => "text/plain",
+        "Content-Type" => "text/plain;charset=utf-8",
         "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
@@ -27,7 +27,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 19,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body: "testing testing 123"
@@ -55,7 +55,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 32,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body: "this is a mocked get with a body"
@@ -83,7 +83,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 32,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body: ""
@@ -100,7 +100,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Accept" => "*/*",
         "Content-Length" => 9,
-        "Content-Type" => "text/plain",
+        "Content-Type" => "text/plain;charset=utf-8",
         "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
@@ -113,7 +113,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 128,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000"
       },
       body:
@@ -142,7 +142,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 0,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000",
         allow: "GET, HEAD, OPTIONS"
       },
@@ -171,7 +171,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 0,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000",
         location: "http://0.0.0.0:4000/test_get"
       },
@@ -189,7 +189,7 @@ defmodule HTTPServerTest.Router do
       headers: %{
         "Accept" => "*/*",
         "Content-Length" => 9,
-        "Content-Type" => "text/plain",
+        "Content-Type" => "text/plain;charset=utf-8",
         "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
@@ -202,7 +202,7 @@ defmodule HTTPServerTest.Router do
       resource: "HTTP/1.1",
       headers: %{
         content_length: 0,
-        content_type: "text/plain",
+        content_type: "text/plain;charset=utf-8",
         host: "0.0.0.0:4000",
         allow: "POST, OPTIONS"
       },


### PR DESCRIPTION
My structured data ticket was becoming colossal because of the refactoring that was needed to accommodate new `:content_type`'s. I wanted to break it down into a needed Response + Header builder refactor, and then open another PR for the tests, routes and additional functionality I will be adding.

Adds:
* `build/4`, `new/0`, `status/2` and `body/2` in Response to handle parsing what's returned from the Request into a Response
* `build/4` and `new/0` in Headers to handle parsing what's returned from the Request into the Headers
* `content/3` in HeadersBuilder to handle different media_types

Changes:
* headers responsibility abstracted away from handlers. Handlers now only have to return `{status_code, body, media_type}`
* Router is now calling `Response.build/4`