### PR TITLE
Create To-Do: 415 and 400 Error Handling

### DIFF
--- a/lib/http_server_fixture/data/test-data.json
+++ b/lib/http_server_fixture/data/test-data.json
@@ -1,1 +1,1 @@
-{"task":"a new task"}
+{}

--- a/lib/http_server_test_fixture/mock_data/test-data.json
+++ b/lib/http_server_test_fixture/mock_data/test-data.json
@@ -1,1 +1,1 @@
-{"todo1":"Act","todo2":"Arrange","todo3":"Assert"}
+{}

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -9,7 +9,7 @@ defmodule HTTPServer.Response do
             body: ""
 
   @type t :: %__MODULE__{
-          status_code: 200 | 204 | 404 | 301 | 405 | 201,
+          status_code: 200 | 204 | 404 | 301 | 405 | 201 | 415 | 400,
           status_message: String.t(),
           resource: String.t(),
           headers: %Headers{},
@@ -59,7 +59,8 @@ defmodule HTTPServer.Response do
       301 => "MOVED PERMANENTLY",
       405 => "METHOD NOT ALLOWED",
       201 => "CREATED",
-      415 => "UNSUPPORTED MEDIA TYPE"
+      415 => "UNSUPPORTED MEDIA TYPE",
+      400 => "BAD REQUEST"
     }[status_code]
   end
 

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -58,7 +58,8 @@ defmodule HTTPServer.Response do
       404 => "NOT FOUND",
       301 => "MOVED PERMANENTLY",
       405 => "METHOD NOT ALLOWED",
-      201 => "CREATED"
+      201 => "CREATED",
+      415 => "UNSUPPORTED MEDIA TYPE"
     }[status_code]
   end
 

--- a/lib/response/body.ex
+++ b/lib/response/body.ex
@@ -1,5 +1,25 @@
 defmodule HTTPServer.Response.Body do
-  def handle(body, :json) do
-    JSON.decode!(body)
+  alias HTTPServer.Request
+  alias HTTPServer.Router.Handlers.UnsupportedMediaType
+  def handle(%Request{body: body, headers: headers} = req, :json) do
+    case is_type(headers, :json) do
+      true -> JSON.decode(body)
+
+      false -> {:error, UnsupportedMediaType.handle(req)}
+    end
+
+  end
+
+  defp is_type(headers, :json) do
+    type = normalize_type(headers)
+
+    type in ["application/*", "application/json"]
+  end
+
+  defp normalize_type(headers) do
+    unless headers["Content-Type"] == nil do
+      [type | _parameter] = headers["Content-Type"] |> String.split(";", parts: 2)
+      type
+    end
   end
 end

--- a/lib/response/body.ex
+++ b/lib/response/body.ex
@@ -1,25 +1,27 @@
 defmodule HTTPServer.Response.Body do
   alias HTTPServer.Request
   alias HTTPServer.Router.Handlers.UnsupportedMediaType
-  def handle(%Request{body: body, headers: headers} = req, :json) do
-    case is_type(headers, :json) do
-      true -> JSON.decode(body)
+  alias HTTPServer.Router.Handlers.BadRequest
 
-      false -> {:error, UnsupportedMediaType.handle(req)}
+  def handle(%Request{headers: headers} = req, :json) do
+    case normalize_type(headers) do
+      ["application", "json"] -> parse_body(req, :json)
+      ["application", _subtype] -> {:error, BadRequest.handle(req)}
+      [_type, _subtype] -> {:error, UnsupportedMediaType.handle(req)}
     end
-
   end
 
-  defp is_type(headers, :json) do
-    type = normalize_type(headers)
-
-    type in ["application/*", "application/json"]
+  defp parse_body(%Request{body: body} = req, :json) do
+    case JSON.decode(body) do
+      {:ok, json_body} -> {:ok, json_body}
+      {:error, _} -> {:error, BadRequest.handle(req)}
+    end
   end
 
   defp normalize_type(headers) do
     unless headers["Content-Type"] == nil do
       [type | _parameter] = headers["Content-Type"] |> String.split(";", parts: 2)
-      type
+      type |> String.split("/", parts: 2)
     end
   end
 end

--- a/lib/router/handlers/bad_request.ex
+++ b/lib/router/handlers/bad_request.ex
@@ -1,10 +1,10 @@
-defmodule HTTPServer.Router.Handlers.UnsupportedMediaType do
+defmodule HTTPServer.Router.Handlers.BadRequest do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
   def handle(_req) do
     body = ""
 
-    {415, body, :text}
+    {400, body, :text}
   end
 end

--- a/lib/router/handlers/unsupported_media_type.ex
+++ b/lib/router/handlers/unsupported_media_type.ex
@@ -1,0 +1,10 @@
+defmodule HTTPServer.Router.Handlers.UnsupportedMediaType do
+  @behaviour HTTPServer.Handler
+
+  @impl HTTPServer.Handler
+  def handle(_req) do
+    body = "Unsupported Media Type"
+
+    {415, body, :text}
+  end
+end

--- a/lib/to_do/api.ex
+++ b/lib/to_do/api.ex
@@ -1,7 +1,7 @@
 defmodule ToDo.API do
   @file_path Application.compile_env(:http_server, :file_path, "lib/to_do/data/to_dos.json")
 
-  def create(data) do
+  def create({:ok, data}) do
     new_save_data =
       File.read!(@file_path)
       |> JSON.decode!()
@@ -9,5 +9,9 @@ defmodule ToDo.API do
       |> JSON.encode!()
 
     File.write(@file_path, new_save_data, [:read, :write])
+  end
+
+  def create({:error, error_message}) do
+    error_message
   end
 end

--- a/lib/to_do/data/to_dos.json
+++ b/lib/to_do/data/to_dos.json
@@ -1,1 +1,1 @@
-{}
+{"task":"eat lunch"}

--- a/lib/to_do/handlers/to_do.ex
+++ b/lib/to_do/handlers/to_do.ex
@@ -7,10 +7,10 @@ defmodule ToDo.Handlers.ToDo do
 
   @impl HTTPServer.Handler
   def handle(%Request{method: "POST", body: body} = req) do
-    decoded_body = Body.handle(body, :json)
+    {status, value} = Body.handle(body, :json)
 
-    case API.create(decoded_body) do
-      :ok -> {201, decoded_body, :json}
+    case API.create({status, value}) do
+      :ok -> {201, value, :json}
       {:error, _} -> NotFound.handle(req)
     end
   end

--- a/lib/to_do/handlers/to_do.ex
+++ b/lib/to_do/handlers/to_do.ex
@@ -6,12 +6,15 @@ defmodule ToDo.Handlers.ToDo do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{method: "POST", body: body} = req) do
-    {status, value} = Body.handle(body, :json)
+  def handle(%Request{method: "POST"} = req) do
+    {status, value} = Body.handle(req, :json)
 
-    case API.create({status, value}) do
+    {status, value}
+    |> API.create()
+    |> case do
       :ok -> {201, value, :json}
       {:error, _} -> NotFound.handle(req)
+      _ -> value
     end
   end
 end

--- a/test/http_response_test.exs
+++ b/test/http_response_test.exs
@@ -198,7 +198,7 @@ defmodule HTTPServerTest.Response do
     assert Response.Body.handle(request, :json) == {:ok, %{"key" => "value"}}
   end
 
-  test "Response.Body.handle/1 should return a 415 status response when Content-Type is not json" do
+  test "Response.Body.handle/1 should return a 415 status response when type is not application/json" do
     request = %Request{
       method: "POST",
       path: "/",
@@ -212,8 +212,48 @@ defmodule HTTPServerTest.Response do
       body: "<type>Not a valid type</type>"
     }
 
-    unsupported_media_type_res = {415, "Unsupported Media Type", :text}
+    unsupported_media_type_res = {415, "", :text}
 
     assert Response.Body.handle(request, :json) == {:error, unsupported_media_type_res}
+  end
+
+  test "Response.Body.handle/1 should return a 400 Bad Request status response when content-type is application/xml" do
+    request = %Request{
+      method: "POST",
+      path: "/",
+      resource: "HTTP/1.1",
+      headers: %{
+        "Accept" => "*/*",
+        "Host" => "0.0.0.0:4000",
+        "Content-Type" => "application/xml",
+        "User-Agent" => "ExampleBrowser/1.0"
+      },
+      body: "<text><para>hello world</para></text>"
+    }
+
+    bad_req_res =
+      {400, "", :text}
+
+    assert Response.Body.handle(request, :json) == {:error, bad_req_res}
+  end
+
+  test "Response.Body.handle/1 should return a 400 Bad Request status response when body is not proper formatted json" do
+    request = %Request{
+      method: "POST",
+      path: "/",
+      resource: "HTTP/1.1",
+      headers: %{
+        "Accept" => "*/*",
+        "Host" => "0.0.0.0:4000",
+        "Content-Type" => "application/json",
+        "User-Agent" => "ExampleBrowser/1.0"
+      },
+      body: "key:"
+    }
+
+    bad_req_res =
+      {400, "", :text}
+
+    assert Response.Body.handle(request, :json) == {:error, bad_req_res}
   end
 end

--- a/test/http_server_spec/features/04_todo_list/create_todo.feature
+++ b/test/http_server_spec/features/04_todo_list/create_todo.feature
@@ -6,12 +6,12 @@ Feature: Create To-Do
     Then my response should have status code 201
     And my response should return JSON
     And my response should have a body with the details of the task
-@wip
+
   Scenario: Trying to create a to-do task with an unsupported media type
     Given I make a POST request with an unsupported media type
     Then my response should have status code 415
     And my response should have an empty body
-@wip
+
   Scenario: Trying to create a to-do item with invalid values
     Given I make a POST request with invalid values
     Then my response should have status code 400

--- a/test/http_to_do_test.exs
+++ b/test/http_to_do_test.exs
@@ -3,7 +3,11 @@ defmodule HTTPServerTest.ToDo do
   use ExUnit.Case, async: true
   doctest HTTPServer
 
-  @file_path Application.compile_env(:http_server, :file_path, "lib/http_server_test_fixture/mock_data/test-data.json")
+  @file_path Application.compile_env(
+               :http_server,
+               :file_path,
+               "lib/http_server_test_fixture/mock_data/test-data.json"
+             )
 
   setup do
     mock_data = JSON.encode!(%{"todo1" => "Act", "todo2" => "Arrange"})
@@ -13,14 +17,22 @@ defmodule HTTPServerTest.ToDo do
 
   test "Can write \"{\"todo3\":\"Assert\"}\" to data file without overwriting previous data" do
     todo_to_add = %{"todo3" => "Assert"}
+    handle_resp = {:ok, todo_to_add}
     expected_file_contents = Map.merge(%{"todo1" => "Act", "todo2" => "Arrange"}, todo_to_add)
 
-    API.create(todo_to_add)
+    API.create(handle_resp)
 
     file_contents =
       File.read!(@file_path)
       |> JSON.decode!()
 
     assert file_contents == expected_file_contents
+  end
+
+  test "Returns error message when passed {:error, \"Error Message\"}" do
+    error_message = "Error Message"
+    handle_resp = {:error, error_message}
+
+    assert API.create(handle_resp) == error_message
   end
 end


### PR DESCRIPTION
**Adds:**
* HTTPServer.Router.Handlers.UnsupportedMediaType and HTTPServer.Router.Handlers.BadRequest
* 415 and 400 status message
* `handle/2`, `normalize_type/1`, `parse_body/2` to evaluate formatting issues
* unit tests for new functionality

**Changes:**
* HTTPServer.Response.Body returns `{:ok, json_body}` when correctly formatted and `{:error, {status_code, "", :text}}` when incorrectly formatted
* `ToDo.API.create/1` pattern matching