### PR TITLE
CAMPSITE: Parsing Path and Params

### DIFF
--- a/lib/http_server.ex
+++ b/lib/http_server.ex
@@ -24,7 +24,7 @@ defmodule HTTPServer do
       socket
       |> read_line()
       |> log("Request:")
-      |> Request.parse_request()
+      |> Request.parse()
 
     response =
       request

--- a/lib/http_server_fixture/data/test-data.json
+++ b/lib/http_server_fixture/data/test-data.json
@@ -1,1 +1,1 @@
-{"1":{"task":"a new task"},"2":{"task":"a new task"}}
+{"1":{"task":"a new task"},"2":{"task":"a new task"},"3":{"task":"a new task"}}

--- a/lib/http_server_fixture/data/test-data.json
+++ b/lib/http_server_fixture/data/test-data.json
@@ -1,1 +1,1 @@
-{}
+{"1":{"task":"a new task"},"2":{"task":"a new task"}}

--- a/lib/http_server_test_fixture/mock_data/test-data.json
+++ b/lib/http_server_test_fixture/mock_data/test-data.json
@@ -1,1 +1,1 @@
-{}
+{"1":{"todo1":"Act"},"2":{"todo2":"Arrange"},"3":{"todo3":"Assert"}}

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -1,4 +1,5 @@
 defmodule HTTPServer.Request do
+  alias HTTPServer.Request.Parser
   defstruct method: "", full_path: [], route_path: "", resource: "", headers: %{}, body: "", params: %{}
 
   @type t :: %__MODULE__{
@@ -11,55 +12,5 @@ defmodule HTTPServer.Request do
           params: %{optional(String.t()) => String.t()}
         }
 
-  @carriage_return "\r\n"
-
-  def parse_request(message) do
-    [request_data, body] = message |> String.split("#{@carriage_return}#{@carriage_return}")
-    [first | headers] = request_data |> String.split("#{@carriage_return}")
-    headers = parse_headers(headers, %{})
-    [method, path, resource] = first |> String.split(" ")
-    params = parse_params(path)
-
-    %__MODULE__{
-      method: method,
-      full_path: parse_path(path),
-      route_path: List.first(parse_path(path)),
-      resource: resource,
-      headers: headers,
-      body: body,
-      params: params
-    }
-  end
-
-  defp parse_headers([head | tail], headers) do
-    [key, value] = head |> String.split(": ")
-    headers = Map.put(headers, key, value)
-    parse_headers(tail, headers)
-  end
-
-  defp parse_headers([], headers), do: headers
-
-  defp parse_path(path) do
-    [path | _query_string] = String.split(path, "?")
-    split(path)
-  end
-
-  defp split(path) do
-    for segment <- String.split(path, "/"), segment != "", do: "/#{segment}"
-  end
-
-  defp parse_params(path) do
-    case String.split(path, "?") do
-      [_] -> nil
-      [_path, query_string] ->
-        query_string
-        |> String.split("&")
-        |> Enum.reduce(%{}, &parse_param/2)
-    end
-  end
-
-  defp parse_param(param_str, acc) do
-    [param_name, param_value] = String.split(param_str, "=")
-    Map.put(acc, param_name, param_value)
-  end
+  def parse(message), do: Parser.parse(message)
 end

--- a/lib/request/parser.ex
+++ b/lib/request/parser.ex
@@ -1,0 +1,56 @@
+defmodule HTTPServer.Request.Parser do
+  alias HTTPServer.Request
+
+  @carriage_return "\r\n"
+  def parse(message) do
+    [request_data, body] = message |> String.split("#{@carriage_return}#{@carriage_return}")
+    [first | headers] = request_data |> String.split("#{@carriage_return}")
+    headers = parse_headers(headers, %{})
+    [method, path, resource] = first |> String.split(" ")
+    params = parse_params(path)
+
+    %Request{
+      method: method,
+      full_path: parse_path(path),
+      route_path: List.first(parse_path(path)),
+      resource: resource,
+      headers: headers,
+      body: body,
+      params: params
+    }
+  end
+
+  defp parse_headers([head | tail], headers) do
+    [key, value] = head |> String.split(": ")
+    headers = Map.put(headers, key, value)
+    parse_headers(tail, headers)
+  end
+
+  defp parse_headers([], headers), do: headers
+
+  defp parse_path(path) do
+    [path | _query_string] = String.split(path, "?")
+    split(path)
+  end
+
+  defp split(path) do
+    for segment <- String.split(path, "/"), segment != "", do: "/#{segment}"
+  end
+
+  defp parse_params(path) do
+    case String.split(path, "?") do
+      [_] ->
+        nil
+
+      [_path, query_string] ->
+        query_string
+        |> String.split("&")
+        |> Enum.reduce(%{}, &parse_param/2)
+    end
+  end
+
+  defp parse_param(param_str, acc) do
+    [param_name, param_value] = String.split(param_str, "=")
+    Map.put(acc, param_name, param_value)
+  end
+end

--- a/lib/response/headers.ex
+++ b/lib/response/headers.ex
@@ -14,21 +14,21 @@ defmodule HTTPServer.Response.Headers do
           allow: list(String.t())
         }
 
-  def build(%Request{method: "OPTIONS", path: path, headers: headers}, _status_code, body, media_type) do
+  def build(%Request{method: "OPTIONS", route_path: path, headers: headers}, _status_code, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)
     |> allow(@routes.routes[path][:methods])
   end
 
-  def build(%Request{path: path, headers: headers}, 405, body, media_type) do
+  def build(%Request{route_path: path, headers: headers}, 405, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)
     |> allow(@routes.routes[path][:methods])
   end
 
-  def build(%Request{path: path, headers: headers}, 301, body, media_type) do
+  def build(%Request{route_path: path, headers: headers}, 301, body, media_type) do
     %__MODULE__{}
     |> content(media_type, body)
     |> host(headers)

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -8,7 +8,7 @@ defmodule HTTPServer.Router do
 
   @routes Application.compile_env(:http_server, :routes, Routes)
 
-  def router(req = %Request{path: path}) do
+  def router(req = %Request{route_path: path}) do
     case Map.fetch(@routes.routes, path) do
       {:ok, path_info} -> route_if_allowed(req, path_info)
       _ -> route_not_found(req)

--- a/lib/router/handlers/not_found.ex
+++ b/lib/router/handlers/not_found.ex
@@ -3,7 +3,7 @@ defmodule HTTPServer.Router.Handlers.NotFound do
   @behaviour HTTPServer.Handler
 
   @impl HTTPServer.Handler
-  def handle(%Request{path: path}) do
+  def handle(%Request{route_path: path}) do
     body =
       "Something went wrong at #{path}. See the README for instructions on how to customize your routes!"
 

--- a/lib/router/handlers/serve_static.ex
+++ b/lib/router/handlers/serve_static.ex
@@ -5,7 +5,7 @@ defmodule HTTPServer.Router.Handlers.ServeStatic do
   @routes Application.compile_env(:http_server, :routes, Routes)
 
   @impl HTTPServer.Handler
-  def handle(req = %Request{path: path}) do
+  def handle(req = %Request{route_path: path}) do
     filepath = @routes.routes[path][:filepath]
 
     case File.read(filepath) do

--- a/test/http_request_parser_test.exs
+++ b/test/http_request_parser_test.exs
@@ -1,4 +1,4 @@
-defmodule HTTPServerTest.Request do
+defmodule HTTPServerTest.Request.Parser do
   use ExUnit.Case
   alias HTTPServer.Request
   doctest HTTPServer
@@ -32,7 +32,7 @@ defmodule HTTPServerTest.Request do
       params: nil
     }
 
-    assert Request.parse_request(message) == expected_parsed_request
+    assert Request.Parser.parse(message) == expected_parsed_request
   end
 
   test "returns properly formatted HTTP POST request" do
@@ -62,7 +62,7 @@ defmodule HTTPServerTest.Request do
       params: nil
     }
 
-    assert Request.parse_request(message) == expected_parsed_request
+    assert Request.Parser.parse(message) == expected_parsed_request
   end
 
   test "returns properly formatted path that seperates the path prefix and the subsequent slugs & params" do
@@ -92,6 +92,6 @@ defmodule HTTPServerTest.Request do
       body: "some body"
     }
 
-    assert Request.parse_request(message) == expected_parsed_request
+    assert Request.Parser.parse(message) == expected_parsed_request
   end
 end

--- a/test/http_request_test.exs
+++ b/test/http_request_test.exs
@@ -18,7 +18,8 @@ defmodule HTTPServerTest.Request do
 
     expected_parsed_request = %Request{
       method: "GET",
-      path: "/simple_get",
+      full_path: ["/simple_get"],
+      route_path: "/simple_get",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -27,7 +28,8 @@ defmodule HTTPServerTest.Request do
         "Host" => "0.0.0.0:4000",
         "User-Agent" => "ExampleBrowser/1.0"
       },
-      body: ""
+      body: "",
+      params: nil
     }
 
     assert Request.parse_request(message) == expected_parsed_request
@@ -46,7 +48,39 @@ defmodule HTTPServerTest.Request do
 
     expected_parsed_request = %Request{
       method: "POST",
-      path: "/echo_body",
+      full_path: ["/echo_body"],
+      route_path: "/echo_body",
+      resource: "HTTP/1.1",
+      headers: %{
+        "Accept" => "*/*",
+        "Content-Length" => "9",
+        "Content-Type" => "text/plain",
+        "Host" => "0.0.0.0:4000",
+        "User-Agent" => "ExampleBrowser/1.0"
+      },
+      body: "some body",
+      params: nil
+    }
+
+    assert Request.parse_request(message) == expected_parsed_request
+  end
+
+  test "returns properly formatted path that seperates the path prefix and the subsequent slugs & params" do
+    message =
+      "GET /example/user_id?param1=value1&param2=value2&param3=value3 HTTP/1.1#{@carriage_return}" <>
+        "Host: 0.0.0.0:4000#{@carriage_return}" <>
+        "User-Agent: ExampleBrowser/1.0#{@carriage_return}" <>
+        "Accept: */*#{@carriage_return}" <>
+        "Content-Type: text/plain#{@carriage_return}" <>
+        "Content-Length: 9#{@carriage_return}" <>
+        "#{@carriage_return}" <>
+        "some body"
+
+    expected_parsed_request = %Request{
+      method: "GET",
+      full_path: ["/example", "/user_id"],
+      route_path: "/example",
+      params: %{"param1" => "value1", "param2" => "value2", "param3" => "value3"},
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",

--- a/test/http_response_test.exs
+++ b/test/http_response_test.exs
@@ -15,7 +15,8 @@ defmodule HTTPServerTest.Response do
 
     request = %Request{
       method: "GET",
-      path: "/simple_get",
+      full_path: ["/simple_get"],
+      route_path: "/simple_get",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -69,7 +70,8 @@ defmodule HTTPServerTest.Response do
   test "a GET request to /test_text should return a text body" do
     request = %Request{
       method: "GET",
-      path: "/test_text",
+      full_path: ["/test_text"],
+      route_path: "/test_text",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -97,7 +99,8 @@ defmodule HTTPServerTest.Response do
   test "a GET request to /test_html should return a html body" do
     request = %Request{
       method: "GET",
-      path: "/test_html",
+      full_path: ["/test_html"],
+      route_path: "/test_html",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -126,7 +129,8 @@ defmodule HTTPServerTest.Response do
   test "a GET request to /test_xml should return a XML body" do
     request = %Request{
       method: "GET",
-      path: "/test_xml",
+      full_path: ["/test_xml"],
+      route_path: "/test_xml",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -154,7 +158,8 @@ defmodule HTTPServerTest.Response do
   test "a GET request to /test_json should return a json body" do
     request = %Request{
       method: "GET",
-      path: "/test_json",
+      full_path: ["/test_json"],
+      route_path: "/test_json",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -184,7 +189,8 @@ defmodule HTTPServerTest.Response do
   test "Response.Body.handle/1 should return a 200 status response and decoded json body" do
     request = %Request{
       method: "POST",
-      path: "/",
+      full_path: ["/"],
+      route_path: "/",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -201,7 +207,8 @@ defmodule HTTPServerTest.Response do
   test "Response.Body.handle/1 should return a 415 status response when type is not application/json" do
     request = %Request{
       method: "POST",
-      path: "/",
+      full_path: ["/"],
+      route_path: "/",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -220,7 +227,8 @@ defmodule HTTPServerTest.Response do
   test "Response.Body.handle/1 should return a 400 Bad Request status response when content-type is application/xml" do
     request = %Request{
       method: "POST",
-      path: "/",
+      full_path: ["/"],
+      route_path: "/",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -240,7 +248,8 @@ defmodule HTTPServerTest.Response do
   test "Response.Body.handle/1 should return a 400 Bad Request status response when body is not proper formatted json" do
     request = %Request{
       method: "POST",
-      path: "/",
+      full_path: ["/"],
+      route_path: "/",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",

--- a/test/http_router_test.exs
+++ b/test/http_router_test.exs
@@ -10,7 +10,8 @@ defmodule HTTPServerTest.Router do
   test "returns properly formatted successful response to POST request at /test_post" do
     request = %Request{
       method: "POST",
-      path: "/test_post",
+      full_path: ["/test_post"],
+      route_path: "/test_post",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -40,7 +41,8 @@ defmodule HTTPServerTest.Router do
   test "returns properly formatted successful response to GET request" do
     request = %Request{
       method: "GET",
-      path: "/test_get",
+      full_path: ["/test_get"],
+      route_path: "/test_get",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -68,7 +70,8 @@ defmodule HTTPServerTest.Router do
   test "returns properly formatted successful response to HEAD request at /test_get" do
     request = %Request{
       method: "HEAD",
-      path: "/test_get",
+      full_path: ["/test_get"],
+      route_path: "/test_get",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -96,7 +99,8 @@ defmodule HTTPServerTest.Router do
   test "returns a 404 Page Not Found when making a request to a path that doesn't exist" do
     request = %Request{
       method: "GET",
-      path: "/test-not-found",
+      full_path: ["/test-not-found"],
+      route_path: "/test-not-found",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -127,7 +131,8 @@ defmodule HTTPServerTest.Router do
   test "returns properly formatted successful response to OPTIONS request at /test_get" do
     request = %Request{
       method: "OPTIONS",
-      path: "/test_get",
+      full_path: ["/test_get"],
+      route_path: "/test_get",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -156,7 +161,8 @@ defmodule HTTPServerTest.Router do
   test "returns 301 redirect response to GET request at /old_path" do
     request = %Request{
       method: "GET",
-      path: "/test_redirect",
+      full_path: ["/test_redirect"],
+      route_path: "/test_redirect",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -185,7 +191,8 @@ defmodule HTTPServerTest.Router do
   test "returns 405 Method Not Found Response to GET request at /test_post" do
     request = %Request{
       method: "GET",
-      path: "/test_post",
+      full_path: ["/test_post"],
+      route_path: "/test_post",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -218,7 +225,8 @@ defmodule HTTPServerTest.Router do
 
     request = %Request{
       method: "GET",
-      path: "/hello-world.txt",
+      full_path: ["/hello-world.txt"],
+      route_path: "/hello-world.txt",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",
@@ -234,7 +242,8 @@ defmodule HTTPServerTest.Router do
   test "returns properly formatted response from mock_html.html file" do
     request = %Request{
       method: "GET",
-      path: "/mock-html.html",
+      full_path: ["/mock-html.html"],
+      route_path: "/mock-html.html",
       resource: "HTTP/1.1",
       headers: %{
         "Accept" => "*/*",


### PR DESCRIPTION
Adds:
* Request.Parser
* `:route_path` and `:full_path` to request struct
* `parse_path/1`, `split/1`, `parse_params/1`, `parse_param/2` helper functions to split path string

Changes:
* all instances of `:path` to `:route_path`
* HTTPServerTest.Request to HTTPServerTest.Request.Parser unit tests