### PR TITLE
CAMPSITE: To-Do Tests Teardown

### DIFF
--- a/lib/http_server_fixture/data/test-data.json
+++ b/lib/http_server_fixture/data/test-data.json
@@ -1,1 +1,0 @@
-{"1":{"task":"a new task"},"2":{"task":"a new task"},"3":{"task":"a new task"}}

--- a/lib/http_server_test_fixture/mock_data/test-data.json
+++ b/lib/http_server_test_fixture/mock_data/test-data.json
@@ -1,1 +1,0 @@
-{"1":{"todo1":"Act"},"2":{"todo2":"Arrange"},"3":{"todo3":"Assert"}}

--- a/lib/to_do/db.ex
+++ b/lib/to_do/db.ex
@@ -1,7 +1,12 @@
 defmodule ToDo.DB do
   @file_path Application.compile_env(:http_server, :file_path, "lib/to_do/data/to_dos.json")
 
-  def all, do: File.read!(@file_path) |> JSON.decode!()
+  def all do
+    case File.exists?(@file_path) do
+      true -> File.read!(@file_path) |> JSON.decode!()
+      false -> %{}
+    end
+  end
 
   def save(data), do: File.write(@file_path, JSON.encode!(data), [:read, :write])
 

--- a/test/http_server_spec/features/support/env.rb
+++ b/test/http_server_spec/features/support/env.rb
@@ -6,3 +6,10 @@ yaml = YAML.load_file(file_path)
 HOSTNAME = yaml["server"]["hostname"]
 PORT = yaml["server"]["port"]
 PROTOCOL = yaml["server"]["protocol"]
+
+Spinach.hooks.after_run do |status|
+    pn = File.expand_path('../../../../lib/http_server_fixture/data/test-data.json', __dir__)
+    File.delete(pn) if File.exist?(pn)
+    file_deleted = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\ntest-data file deleted\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    puts file_deleted unless File.exist?(pn)
+end

--- a/test/http_to_do_test.exs
+++ b/test/http_to_do_test.exs
@@ -1,6 +1,6 @@
 defmodule HTTPServerTest.ToDo do
   alias ToDo.API
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest HTTPServer
 
   @file_path Application.compile_env(
@@ -12,6 +12,8 @@ defmodule HTTPServerTest.ToDo do
   setup do
     act_arrange_test_todo = JSON.encode!(%{"1" => %{"todo1" => "Act"}, "2" => %{"todo2" => "Arrange"}})
     File.write!(@file_path, act_arrange_test_todo)
+    on_exit(fn -> if File.exists?(@file_path), do: File.rm!(@file_path) end)
+    :ok
   end
 
   test "Can write \"{\"todo3\":\"Assert\"}\" to data file without overwriting previous data" do

--- a/test/http_to_do_test.exs
+++ b/test/http_to_do_test.exs
@@ -1,6 +1,6 @@
 defmodule HTTPServerTest.ToDo do
   alias ToDo.API
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   doctest HTTPServer
 
   @file_path Application.compile_env(
@@ -11,7 +11,7 @@ defmodule HTTPServerTest.ToDo do
 
   setup do
     act_arrange_test_todo = JSON.encode!(%{"1" => %{"todo1" => "Act"}, "2" => %{"todo2" => "Arrange"}})
-    File.write!(@file_path, act_arrange_test_todo)
+    File.write(@file_path, act_arrange_test_todo)
     on_exit(fn -> if File.exists?(@file_path), do: File.rm!(@file_path) end)
     :ok
   end


### PR DESCRIPTION
**Adds:**
* `on_exit/1` statement to HTTPServerTest.ToDo
* after_run hook in `env.rb`

**Changes:** 
* `ToDo.DB.all/0` to return an empty map if file does not exist
* Disables asynchronous test execution, which was causing failure in the pervious Teardown Campsite PR